### PR TITLE
Change conference / overhaul whatif system

### DIFF
--- a/src/Client/Client.fsproj
+++ b/src/Client/Client.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="Counter/Types.fs" />
     <Compile Include="Counter/State.fs" />
     <Compile Include="Counter/View.fs" />
+    <Compile Include="Conference/ConferenceInformation.fs" />
     <Compile Include="Conference/Types.fs" />
     <Compile Include="Conference/Ws.fs" />
     <Compile Include="Conference/State.fs" />

--- a/src/Client/Conference/ConferenceInformation.fs
+++ b/src/Client/Conference/ConferenceInformation.fs
@@ -98,7 +98,7 @@ module View =
                 inputType
                 Input.typeIsText
                 Input.placeholder label
-                Input.defaultValue field
+                Input.value field
                 Input.props [ OnChange (fun event -> !!event.target?value |>changeMsg) ]
               ]
             Icon.faIcon

--- a/src/Client/Conference/ConferenceInformation.fs
+++ b/src/Client/Conference/ConferenceInformation.fs
@@ -1,0 +1,150 @@
+namespace Conference.ConferenceInformation
+
+open Fable.Helpers.React
+open Fable.Helpers.React.Props
+open Fable.Core.JsInterop
+open Fulma.Elements
+open Fulma.Elements.Form
+open Fulma.Extra.FontAwesome
+
+module Types =
+  type Model =
+    {
+      Title : string
+      AvailableSlotsForTalks : string
+    }
+
+  type Errors =
+    {
+      Title : string option
+      AvailableSlotsForTalks : string option
+    }
+
+  let isInteger str =
+    str
+    |> System.Int32.TryParse
+    |> function | (true, _) -> true | _ -> false
+
+  let validate (model : Model) : Errors =
+    let title =
+      if model.Title |> System.String.IsNullOrEmpty then
+        "Should not be empty" |> Some
+      else
+        None
+
+    let availableSlotsForTalks =
+      if model.AvailableSlotsForTalks |> System.String.IsNullOrEmpty then
+        "Should not be empty" |> Some
+      elif model.AvailableSlotsForTalks |> isInteger |> not then
+        "Must be an integer" |> Some
+      else
+        None
+
+    {
+      Title = title
+      AvailableSlotsForTalks = availableSlotsForTalks
+    }
+
+  let title (model : Model) =
+    model.Title
+
+  let availableSlotsForTalks (model : Model) =
+    model.AvailableSlotsForTalks
+    |> System.Int32.TryParse
+    |> function | (true, value) -> value | _ -> 0
+
+  let isValid model =
+    let errors =
+      model |> validate
+
+    errors.Title.IsNone && errors.AvailableSlotsForTalks.IsNone
+
+
+  type Msg =
+    | TitleChanged of string
+    | AvailableSlotsForTalksChanged of string
+
+
+module View =
+  open Types
+
+  let private typeAndIconAndError error =
+    match error with
+    | Some error ->
+        let help =
+          Help.help
+            [ Help.isDanger ]
+            [ str error ]
+
+        Input.isDanger,Fa.I.Times,help
+
+    | None ->
+        Input.isSuccess,Fa.I.Check,str ""
+
+  let private viewFormField changeMsg field error label =
+    let inputType,inputIcon,inputError =
+      error |> typeAndIconAndError
+
+    Form.Field.field_div []
+      [
+        Label.label [] [ str label ]
+        Control.control_div
+          [
+             Control.hasIconRight
+          ]
+          [
+            Input.input
+              [
+                inputType
+                Input.typeIsText
+                Input.placeholder label
+                Input.defaultValue field
+                Input.props [ OnChange (fun event -> !!event.target?value |>changeMsg) ]
+              ]
+            Icon.faIcon
+              [
+                Icon.isSmall
+                Icon.isRight
+              ]
+              [ Fa.icon inputIcon ]
+
+          ]
+        inputError
+      ]
+
+  let view dispatch model =
+    let errors =
+      model |> validate
+
+    form [ ]
+      [
+        viewFormField
+          (TitleChanged>>dispatch)
+          model.Title
+          errors.Title
+          "Conference Title"
+
+        viewFormField
+          (AvailableSlotsForTalksChanged>>dispatch)
+          model.AvailableSlotsForTalks
+          errors.AvailableSlotsForTalks
+          "Available Slots For Talks"
+    ]
+
+module State =
+  open Types
+
+  let init title availableSlotsForTalks : Model =
+    {
+      Title = title
+      AvailableSlotsForTalks = availableSlotsForTalks
+    }
+
+  let update msg model : Model =
+    match msg with
+    | TitleChanged title ->
+        { model with Title = title }
+
+    | AvailableSlotsForTalksChanged number ->
+        { model with AvailableSlotsForTalks = number }
+

--- a/src/Client/Conference/State.fs
+++ b/src/Client/Conference/State.fs
@@ -46,7 +46,7 @@ let queryOrganizers =
 
 let init() =
   {
-    View = View.NotAsked
+    View = CurrentView.NotAsked
     Conferences = RemoteData.NotAsked
     Organizers = RemoteData.NotAsked
     LastEvents = []
@@ -63,7 +63,7 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
       | Handled result ->
           match result with
           | API.QueryResult.Conference conference ->
-              { model with View = (VotingPanel,conference,Live) |> Editor }, Cmd.none
+              { model with View = (VotingPanel,conference,Live) |> Edit }, Cmd.none
 
           | API.QueryResult.Conferences conferences ->
               { model with Conferences = conferences |> Success }, Cmd.none
@@ -79,7 +79,7 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
 
   | Received (ServerMsg.Events eventSet) ->
       match model.View with
-      | Editor (editor, conference, Live) when eventSetIsForCurrentConference eventSet conference  ->
+      | Edit (editor, conference, Live) when eventSetIsForCurrentConference eventSet conference  ->
           let events =
             eventSet |> (fun (_,events) -> events)
 
@@ -87,7 +87,7 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
             events |> updateStateWithEvents conference
 
           { model with
-              View = (editor,newConference,Live) |> Editor
+              View = (editor,newConference,Live) |> Edit
               LastEvents = events
           }, Cmd.none
 
@@ -96,10 +96,10 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
 
   | Vote voting ->
       match model.View with
-      | Editor (_, conference, Live) ->
+      | Edit (_, conference, Live) ->
            model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader, voting |> Commands.Vote)
 
-      | Editor (editor, conference, WhatIf whatif) ->
+      | Edit (editor, conference, WhatIf whatif) ->
           let events =
             conference |> Behaviour.vote voting
 
@@ -117,17 +117,17 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
                   Commands = commands
               }
 
-          { model with View = (editor,newConference,whatif) |> Editor }, Cmd.none
+          { model with View = (editor,newConference,whatif) |> Edit }, Cmd.none
 
       | _ ->
            model, Cmd.none
 
   | RevokeVoting voting ->
       match model.View with
-      | Editor (_, conference, Live) ->
+      | Edit (_, conference, Live) ->
            model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader, voting |> Commands.RevokeVoting)
 
-      | Editor (editor, conference, WhatIf whatif) ->
+      | Edit (editor, conference, WhatIf whatif) ->
           let events =
             conference |> Behaviour.revokeVoting voting
 
@@ -145,17 +145,17 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
                   Commands = commands
               }
 
-          { model with View = (editor,newConference,whatif) |> Editor }, Cmd.none
+          { model with View = (editor,newConference,whatif) |> Edit }, Cmd.none
 
       | _ ->
            model, Cmd.none
 
   | FinishVotingperiod ->
       match model.View with
-      | Editor (_, conference, Live) ->
+      | Edit (_, conference, Live) ->
           model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader,Commands.FinishVotingPeriod)
 
-      | Editor (editor, conference, WhatIf whatif) ->
+      | Edit (editor, conference, WhatIf whatif) ->
           let events =
             conference |> Behaviour.finishVotingPeriod
 
@@ -173,17 +173,17 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
                   Commands = commands
               }
 
-          { model with View = (editor,newConference,whatif) |> Editor }, Cmd.none
+          { model with View = (editor,newConference,whatif) |> Edit }, Cmd.none
 
       | _ ->
            model, Cmd.none
 
   | ReopenVotingperiod ->
       match model.View with
-      | Editor (_, conference, Live) ->
+      | Edit (_, conference, Live) ->
           model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader,Commands.ReopenVotingPeriod)
 
-      | Editor (editor, conference, WhatIf whatif) ->
+      | Edit (editor, conference, WhatIf whatif) ->
           let events =
             conference |> Behaviour.reopenVotingPeriod
 
@@ -201,17 +201,17 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
                   Commands = commands
               }
 
-          { model with View = (editor,newConference,whatif) |> Editor }, Cmd.none
+          { model with View = (editor,newConference,whatif) |> Edit }, Cmd.none
 
       | _ ->
            model, Cmd.none
 
   | AddOrganizerToConference organizer ->
       match model.View with
-      | Editor (_, conference, Live) ->
+      | Edit (_, conference, Live) ->
           model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader, organizer |> Commands.AddOrganizerToConference)
 
-      | Editor (editor, conference, WhatIf whatif) ->
+      | Edit (editor, conference, WhatIf whatif) ->
           let events =
             conference |> Behaviour.addOrganizerToConference organizer
 
@@ -229,17 +229,17 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
                   Commands = commands
               }
 
-          { model with View = (editor,newConference,whatif) |> Editor }, Cmd.none
+          { model with View = (editor,newConference,whatif) |> Edit }, Cmd.none
 
       | _ ->
            model, Cmd.none
 
   | RemoveOrganizerFromConference organizer ->
       match model.View with
-      | Editor (_, conference, Live) ->
+      | Edit (_, conference, Live) ->
           model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader, organizer |> Commands.RemoveOrganizerFromConference)
 
-      | Editor (editor, conference, WhatIf whatif) ->
+      | Edit (editor, conference, WhatIf whatif) ->
           let events =
             conference |> Behaviour.removeOrganizerFromConference organizer
 
@@ -257,20 +257,20 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
                   Commands = commands
               }
 
-          { model with View = (editor,newConference,whatif) |> Editor }, Cmd.none
+          { model with View = (editor,newConference,whatif) |> Edit }, Cmd.none
 
       | _ ->
            model, Cmd.none
 
   | MakeItSo ->
       match model.View with
-      | Editor (editor, conference, WhatIf whatif)  ->
+      | Edit (editor, conference, WhatIf whatif)  ->
           let wsCmds =
             whatif.Commands
             |> List.rev
             |> List.collect (ClientMsg.Command >> wsCmd)
 
-          { model with View = (editor,whatif.Conference,Live) |> Editor },
+          { model with View = (editor,whatif.Conference,Live) |> Edit },
           wsCmds @ (conference.Id |> queryConference)
 
       | _ ->
@@ -278,7 +278,7 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
 
   | ToggleMode ->
       match model.View with
-      | Editor (editor, conference, Live) ->
+      | Edit (editor, conference, Live) ->
           let whatif =
             {
               Conference = conference
@@ -286,10 +286,10 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
               Events = []
             }
 
-          { model with View = (editor,conference, whatif |> WhatIf) |> Editor }, Cmd.none
+          { model with View = (editor,conference, whatif |> WhatIf) |> Edit }, Cmd.none
 
-      | Editor (editor, conference, WhatIf _) ->
-          { model with View = (editor, conference,Live) |> Editor },
+      | Edit (editor, conference, WhatIf _) ->
+          { model with View = (editor, conference,Live) |> Edit },
           conference.Id |> queryConference
 
       | _ ->
@@ -298,10 +298,62 @@ let update (msg : Msg) (model : Model) : Model * Cmd<Msg> =
   | SwitchToConference conferenceId ->
       model, conferenceId |> queryConference
 
-  | SwitchToEditor editor ->
+  | SwitchToEditor target ->
       match model.View with
-      | Editor (_, conference, mode) ->
-          { model with View = (editor, conference, mode) |> Editor },
+      | Edit (_, conference, mode) ->
+          let editor =
+            match target with
+            | AvailableEditor.ConferenceInformation ->
+                ConferenceInformation.State.init conference.Title (conference.AvailableSlotsForTalks |> string)
+                |> Editor.ConferenceInformation
+
+            | AvailableEditor.VotingPanel ->
+                Editor.VotingPanel
+
+            | AvailableEditor.Organizers ->
+                Editor.Organizers
+
+          { model with View = (editor, conference, mode) |> Edit },
+          Cmd.none
+
+      | _ ->
+          model, Cmd.none
+
+  | ResetConferenceInformation ->
+      match model.View with
+      | Edit (ConferenceInformation _, conference, mode) ->
+          let editor =
+            ConferenceInformation.State.init conference.Title (conference.AvailableSlotsForTalks |> string)
+            |> Editor.ConferenceInformation
+
+          { model with View = (editor, conference, mode) |> Edit },
+          Cmd.none
+
+      | _ ->
+          model, Cmd.none
+
+  // | UpdateConferenceInformation ->
+  //     match model.View with
+  //     | Edit (ConferenceInformation submodel, conference, whatif) when submodel |> ConferenceInformation.Types.isValid ->
+  //         let title =
+  //           submodel |> ConferenceInformation.Types.title
+
+  //         let availableSlotsForTalks =
+  //           submodel |> ConferenceInformation.Types.availableSlotsForTalks
+
+  //         model, wsCmd <| ClientMsg.Command (conference.Id |> commandHeader, organizer |> Commands.RemoveOrganizerFromConference)
+
+
+  //     | _ ->
+  //          model, Cmd.none
+
+  | ConferenceInformationMsg msg ->
+      match model.View with
+      | Edit (ConferenceInformation submodel, conference, mode) ->
+          let newSubmodel =
+            submodel |> ConferenceInformation.State.update msg
+
+          { model with View = (ConferenceInformation newSubmodel, conference, mode) |> Edit },
           Cmd.none
 
       | _ ->

--- a/src/Client/Conference/Types.fs
+++ b/src/Client/Conference/Types.fs
@@ -6,10 +6,11 @@ open Server.ServerTypes
 open Model
 open Conference.Api
 
-type Editor =
+type AvailableEditor =
   | VotingPanel
   | Organizers
-  | ConferenceData
+  | ConferenceInformation
+
 
 type Msg =
   | Received of ServerMsg<Events.Event,API.QueryResult>
@@ -22,7 +23,10 @@ type Msg =
   | RemoveOrganizerFromConference of Organizer
   | MakeItSo
   | SwitchToConference of ConferenceId
-  | SwitchToEditor of Editor
+  | SwitchToEditor of AvailableEditor
+  | ResetConferenceInformation
+  | UpdateConferenceInformation
+  | ConferenceInformationMsg of ConferenceInformation.Types.Msg
 
 type WhatIf =
   {
@@ -35,17 +39,33 @@ type Mode =
   | Live
   | WhatIf of WhatIf
 
-type View =
+type Editor =
+  | VotingPanel
+  | Organizers
+  | ConferenceInformation of ConferenceInformation.Types.Model
+
+type CurrentView =
   | NotAsked
   | Loading
   | Error of string
-  | Editor of Editor * Model.Conference * Mode
+  | Edit of Editor * Model.Conference * Mode
 
 type Model =
   {
-    View : View
+    View : CurrentView
     Conferences : RemoteData<Conferences.Conferences>
     Organizers : RemoteData<Model.Organizers>
     LastEvents : Events.Event list
     Organizer : OrganizerId
   }
+
+let matchEditorWithAvailableEditor editor =
+  match editor with
+  | Editor.VotingPanel ->
+      AvailableEditor.VotingPanel
+
+  | Editor.Organizers ->
+      AvailableEditor.Organizers
+
+  | Editor.ConferenceInformation _ ->
+      AvailableEditor.ConferenceInformation

--- a/src/Client/Conference/Types.fs
+++ b/src/Client/Conference/Types.fs
@@ -18,6 +18,8 @@ type WhatIfMsg =
   | ReopenVotingperiod
   | AddOrganizerToConference of Organizer
   | RemoveOrganizerFromConference of Organizer
+  | ChangeTitle of string
+  | DecideNumberOfSlots of int
 
 type Msg =
   | Received of ServerMsg<Events.Event,API.QueryResult>

--- a/src/Client/Conference/Types.fs
+++ b/src/Client/Conference/Types.fs
@@ -11,16 +11,18 @@ type AvailableEditor =
   | Organizers
   | ConferenceInformation
 
-
-type Msg =
-  | Received of ServerMsg<Events.Event,API.QueryResult>
+type WhatIfMsg =
   | Vote of Voting
   | RevokeVoting of Voting
   | FinishVotingperiod
-  | ToggleMode
   | ReopenVotingperiod
   | AddOrganizerToConference of Organizer
   | RemoveOrganizerFromConference of Organizer
+
+type Msg =
+  | Received of ServerMsg<Events.Event,API.QueryResult>
+  | WhatIfMsg of WhatIfMsg
+  | ToggleMode
   | MakeItSo
   | SwitchToConference of ConferenceId
   | SwitchToEditor of AvailableEditor

--- a/src/Client/Conference/View.fs
+++ b/src/Client/Conference/View.fs
@@ -61,8 +61,8 @@ let viewVotingButtons dispatch user vote (talk : Model.ConferenceAbstract) =
 
   let buttonMapper (voting,btnType,label) =
     viewVotingButton
-      (fun _ -> voting |> Msg.Vote |> dispatch)
-      (fun _ -> voting |> Msg.RevokeVoting |> dispatch)
+      (fun _ -> voting |> WhatIfMsg.Vote |> WhatIfMsg |> dispatch)
+      (fun _ -> voting |> WhatIfMsg.RevokeVoting |> WhatIfMsg |> dispatch)
       (vote = Some voting)
       btnType
       label
@@ -120,7 +120,7 @@ let viewTalk dispatch user votings (talk : Model.ConferenceAbstract) =
         ]
     ]
 
-let simpleButton txt action dispatch =
+let simpleButton txt dispatch action =
   Column.column []
     [
        a
@@ -169,10 +169,9 @@ let private viewVotingPanel dispatch user conference =
       [
         match conference.VotingPeriod with
         | InProgress ->
-            yield simpleButton "Finish Votingperiod" FinishVotingperiod dispatch
-
+            yield simpleButton "Finish Votingperiod" (WhatIfMsg>>dispatch) FinishVotingperiod
         | Finished ->
-            yield simpleButton "Reopen Votingperiod" ReopenVotingperiod dispatch
+            yield simpleButton "Reopen Votingperiod" (WhatIfMsg>>dispatch) ReopenVotingperiod
       ]
 
     [ "Proposed"; "Accepted" ; "Rejected"]
@@ -205,7 +204,7 @@ let private viewOrganizer dispatch conference (organizer : Organizer) =
           Switch.isChecked isAddedToConference
           Switch.isRounded
           Switch.isPrimary
-          Switch.onChange (fun _ -> organizer |> changeMsg |> dispatch)
+          Switch.onChange (fun _ -> organizer |> changeMsg |> WhatIfMsg |> dispatch)
         ]
         []
   [

--- a/src/Client/Conference/View.fs
+++ b/src/Client/Conference/View.fs
@@ -484,7 +484,7 @@ let private viewConferenceInformationPanel dispatch submodel =
           [
             Button.button_a
               [
-                // Button.onClick (fun _ -> dispatch Click)
+                yield Button.onClick (fun _ -> dispatch UpdateConferenceInformation)
                 yield Button.isPrimary
                 if submodel |> ConferenceInformation.Types.isValid |> not then
                   yield Button.isDisabled

--- a/src/Client/Conference/View.fs
+++ b/src/Client/Conference/View.fs
@@ -272,7 +272,7 @@ let messageWindowType events =
 let footer currentView lastEvents =
   let content =
     match currentView with
-    | Editor (_,_,mode) ->
+    | Edit (_,_,mode) ->
         let window =
           match mode with
           | WhatIf whatif ->
@@ -313,16 +313,16 @@ let viewConferenceDropdownItem dispatch (conferenceId, title) =
 
 let private viewActiveConference currentView =
   match currentView with
-  | View.Editor (_, conference, _) ->
+  | CurrentView.Edit (_, conference, _) ->
       conference.Title
 
-  |  View.NotAsked ->
+  |  CurrentView.NotAsked ->
       pleaseSelectAConference
 
-  | View.Loading ->
+  | CurrentView.Loading ->
       "Loading..."
 
-  | View.Error _ ->
+  | CurrentView.Error _ ->
       "Error loading conference"
 
 let viewConferenceList dispatch currentView conferences =
@@ -352,15 +352,18 @@ let viewConferenceList dispatch currentView conferences =
       |> div [ ClassName "columns" ]
 
 
-let private viewTab currentView selectEditorMsg editor label =
+let private viewTab currentView selectEditorMsg targetEditor label =
   match currentView with
-  | Editor (currentEditor, _, _) ->
+  | Edit (currentEditor, _, _) ->
+      let currentTarget =
+        currentEditor |> matchEditorWithAvailableEditor
+
       Tabs.tab
         [
-          if currentEditor = editor then
+          if currentTarget = targetEditor then
             yield Tabs.Tab.isActive
 
-          yield Tabs.Tab.props [ OnClick (fun _ -> editor |> selectEditorMsg) ]
+          yield Tabs.Tab.props [ OnClick (fun _ -> targetEditor |> selectEditorMsg) ]
         ]
         [ a [ ] [str label] ]
 
@@ -390,13 +393,13 @@ let viewMakeItSo dispatch =
 
 let private viewModeControls dispatch currentView =
   match currentView with
-  | Editor (_,_,WhatIf _) ->
+  | Edit (_,_,WhatIf _) ->
       [
         viewMakeItSo dispatch
         viewWhatIfSwitch dispatch true
       ]
 
-  | Editor (_,_,Live) ->
+  | Edit (_,_,Live) ->
       [
         viewWhatIfSwitch dispatch false
       ]
@@ -446,8 +449,9 @@ let viewHeader dispatch currentView conferences =
         Tabs.isBoxed
       ]
       [
-        viewTab currentView selectEditorMsg VotingPanel "Votings"
-        viewTab currentView selectEditorMsg Organizers "Organizers"
+        viewTab currentView selectEditorMsg AvailableEditor.ConferenceInformation "Information"
+        viewTab currentView selectEditorMsg AvailableEditor.VotingPanel "Votings"
+        viewTab currentView selectEditorMsg AvailableEditor.Organizers "Organizers"
       ]
 
   [
@@ -456,13 +460,61 @@ let viewHeader dispatch currentView conferences =
   ]
   |> Container.container [ Container.isFluid ]
 
+
+let private viewConferenceInformationPanel dispatch submodel =
+  [
+    Columns.columns []
+      [
+        Column.column
+          [
+            Column.Width.isHalf
+            Column.Offset.isOneThird
+          ]
+          [
+            ConferenceInformation.View.view (ConferenceInformationMsg>>dispatch) submodel
+          ]
+      ]
+
+    Columns.columns []
+      [
+        Column.column
+          [
+            Column.Width.isHalf
+            Column.Offset.isOneThird
+          ]
+          [
+            Button.button_a
+              [
+                // Button.onClick (fun _ -> dispatch Click)
+                yield Button.isPrimary
+                if submodel |> ConferenceInformation.Types.isValid |> not then
+                  yield Button.isDisabled
+
+              ]
+              [ str "Save" ]
+
+            Button.button_a
+              [
+                Button.onClick (fun _ -> ResetConferenceInformation |> dispatch)
+                Button.isWarning
+              ]
+              [ str "Reset" ]
+          ]
+      ]
+  ]
+  |> div []
+
+
 let viewCurrentView dispatch user currentView organizers =
   match currentView with
-  | Editor (VotingPanel, conference, _) ->
+  | Edit (VotingPanel, conference, _) ->
       viewVotingPanel dispatch user conference
 
-  | Editor (Organizers, conference, _) ->
+  | Edit (Organizers, conference, _) ->
       viewOrganizersPanel dispatch conference organizers
+
+  | Edit (ConferenceInformation submodel, _, _) ->
+      viewConferenceInformationPanel dispatch submodel
 
   | _ ->
       [

--- a/src/Domain.Tests/ChangeTitle_Test.fs
+++ b/src/Domain.Tests/ChangeTitle_Test.fs
@@ -1,0 +1,17 @@
+module ChangeTitleTest
+
+open NUnit.Framework
+
+open Commands
+open Events
+open Testbase
+
+
+[<Test>]
+let ``Title can be changed`` () =
+  Given
+    [
+      TitleChanged "Old Title"
+    ]
+  |> When (ChangeTitle "New Title")
+  |> ThenExpect [ TitleChanged "New Title" ]

--- a/src/Domain.Tests/DecideNumberOfSlots_Test.fs
+++ b/src/Domain.Tests/DecideNumberOfSlots_Test.fs
@@ -1,0 +1,17 @@
+module DecideNumberOfSlotsTest
+
+open NUnit.Framework
+
+open Commands
+open Events
+open Testbase
+
+
+[<Test>]
+let ``Number of slots can be decided`` () =
+  Given
+    [
+      NumberOfSlotsDecided 2
+    ]
+  |> When (DecideNumberOfSlots 5)
+  |> ThenExpect [ NumberOfSlotsDecided 5 ]

--- a/src/Domain.Tests/Domain.Tests.fsproj
+++ b/src/Domain.Tests/Domain.Tests.fsproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <None Include="app.config" />
     <Compile Include="Testbase.fs" />
+    <Compile Include="ChangeTitle_Test.fs" />
+    <Compile Include="DecideNumberOfSlots_Test.fs" />
     <Compile Include="FinishVotingPeriod_Test.fs" />
     <Compile Include="ProposeAbstract_Test.fs" />
     <Compile Include="Vote_Test.fs" />

--- a/src/Domain/Behaviour.fs
+++ b/src/Domain/Behaviour.fs
@@ -4,7 +4,6 @@ open Model
 open Commands
 open Events
 open Projections
-open Model
 
 let (|OrganizerAlreadyInConference|_|) organizers organizer =
   match organizers |> List.contains organizer with
@@ -180,6 +179,21 @@ let revokeVoting voting conference =
 
       | _ -> [ VotingWasRevoked voting ]
 
+let changeTitle title _ =
+  [ TitleChanged title ]
+
+let handleChangeTitle givenHistory title =
+  givenHistory
+  |> conferenceState
+  |> changeTitle title
+
+let decideNumberOfSlots number _ =
+  [ NumberOfSlotsDecided number ]
+
+let handleDecideNumberOfSlots givenHistory number =
+  givenHistory
+  |> conferenceState
+  |> decideNumberOfSlots number
 
 let handleRevokeVoting givenHistory voting =
   givenHistory
@@ -227,6 +241,12 @@ let execute (givenHistory : Event list) (command : Command) : Event list =
   | ScheduleConference conference ->
       conference |> handleScheduleConference givenHistory
 
+  | ChangeTitle title ->
+      handleChangeTitle givenHistory title
+
+  | DecideNumberOfSlots number ->
+      handleDecideNumberOfSlots givenHistory number
+
   | AddOrganizerToConference organizer ->
       handleAddOrganizerToConference givenHistory organizer
 
@@ -250,3 +270,4 @@ let execute (givenHistory : Event list) (command : Command) : Event list =
 
   | AcceptAbstract(_) -> failwith "Not Implemented"
   | RejectAbstract(_) -> failwith "Not Implemented"
+

--- a/src/Domain/Commands.fs
+++ b/src/Domain/Commands.fs
@@ -4,6 +4,8 @@ open Model
 
 type Command =
   | ScheduleConference of Conference
+  | ChangeTitle of string
+  | DecideNumberOfSlots of int
   | AddOrganizerToConference of Organizer
   | RemoveOrganizerFromConference of Organizer
   | Vote of Voting

--- a/src/Domain/Events.fs
+++ b/src/Domain/Events.fs
@@ -12,6 +12,7 @@ type Event =
   | TalkWasProposed of ConferenceAbstract
   | CallForPapersOpened
   | CallForPapersClosed
+  | TitleChanged of string
   | NumberOfSlotsDecided of int
   | VotingWasIssued of Voting
   | VotingWasRevoked of Voting
@@ -36,6 +37,7 @@ let isError event =
   | TalkWasProposed _ -> false
   | CallForPapersOpened -> false
   | CallForPapersClosed -> false
+  | TitleChanged _ -> false
   | NumberOfSlotsDecided _ -> false
   | VotingWasIssued _ -> false
   | VotingWasRevoked _ -> false

--- a/src/Domain/Projections.fs
+++ b/src/Domain/Projections.fs
@@ -33,8 +33,11 @@ let apply (conference : Conference) event : Conference =
     | CallForPapersClosed ->
         { conference with CallForPapers = Closed; VotingPeriod = InProgress }
 
-    | NumberOfSlotsDecided i ->
-        { conference with AvailableSlotsForTalks = i }
+    | TitleChanged title ->
+        { conference with Title = title }
+
+    | NumberOfSlotsDecided number ->
+        { conference with AvailableSlotsForTalks = number }
 
     | AbstractWasProposed proposed ->
         { conference with Abstracts = proposed :: conference.Abstracts }


### PR DESCRIPTION
New Tab to change the conference title and the number of available slots (with submodel)

To prevent boilerplate all whatif messages belong to a specific type now. This allows to write cleaner and simpler update functions.

Introduced some Helpers